### PR TITLE
Remove static declaration of shared memory size 

### DIFF
--- a/cuda/gemv_A16fWnO16f_int32packing.cu
+++ b/cuda/gemv_A16fWnO16f_int32packing.cu
@@ -305,7 +305,7 @@ torch::Tensor gemv_A16fWniO16f(torch::Tensor x, torch::Tensor W, const float w_z
     half* y_ptr          = reinterpret_cast<half*>(y.data_ptr<at::Half>());
 
     //Shared memory size
-    static size_t shared_mem_size = x_cols * sizeof(half); //W_rows , x_cols
+    size_t shared_mem_size = x_cols * sizeof(half); //W_rows , x_cols
 
     switch (W_nbits){
       case 8: gemv_A16fW8iO16f_kernel<<<grid_size, block_size, shared_mem_size>>>(x_ptr, W_ptr, y_ptr, x_rows, x_cols, W_rows, W_cols, w_zero, w_scale); break; 

--- a/cuda/gemv_A8iWnO32i_int32packing.cu
+++ b/cuda/gemv_A8iWnO32i_int32packing.cu
@@ -222,7 +222,7 @@ torch::Tensor gemv_A8iWniO32i(torch::Tensor x, torch::Tensor W, const int w_zero
     int32_t* y_ptr       = reinterpret_cast<int32_t*>(y.data_ptr<int32_t>());
 
     //Shared memory size
-    static size_t shared_mem_size = x_cols * sizeof(int8_t); //W_rows , x_cols
+    size_t shared_mem_size = x_cols * sizeof(int8_t); //W_rows , x_cols
 
     switch (W_nbits){
       case 8: gemv_A8iW8iO32i_kernel<<<grid_size, block_size, shared_mem_size>>>(x_ptr, W_ptr, y_ptr, x_rows, x_cols, W_rows, W_cols, w_zero); break; 


### PR DESCRIPTION
The current implementation uses a `static` deleration for `shared_mem_size`, 

https://github.com/mobiusml/gemlite/blob/3c102d8cd1eb36006f579bfe091871787c50521d/cuda/gemv_A8iWnO32i_int32packing.cu#L224-L225

This static declaration causes `shared_mem_size` to be initialized only once, typically with the first value of `x_cols`. The subsequent kernel launches reuse this initialize value, leading to potential illegal memory accesses when testing shapes with ascending order of size.

- Code to reproduce the bug
```diff
# benchmark.py
- for shape_pair in shapes:
+ for shape_pair in shapes[::-1]:
```

- Log
```bash
...
    return torch._C._cuda_synchronize()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
```

- Some concerns:
Not sure if this change will impact performance or not.