### PR TITLE
triton.autotune only closest M values

### DIFF
--- a/gemlite/core.py
+++ b/gemlite/core.py
@@ -3,6 +3,7 @@
 import torch
 import numpy as np
 from enum import Enum
+import math
 
 # CUDA extension
 import gemlite_lib
@@ -179,8 +180,8 @@ GEMLITE_TRITON_MAPPING = {
 }
 
 def get_closest_m(M):
-    allowed_m_values = [1, 2, 4, 8, 16, 32, 64, 128]  # Add or modify as needed
-    return min(allowed_m_values, key=lambda x: abs(x - M))
+    if M <= 8: return M
+    else:      return 2 ** int(math.ceil(math.log2(M)))
 
 # Triton
 class GemLiteLinearTriton(torch.nn.Module):

--- a/gemlite/core.py
+++ b/gemlite/core.py
@@ -178,6 +178,9 @@ GEMLITE_TRITON_MAPPING = {
     ("BF16", "GEMM"): gemm_A16fWnO16f_int32packing,
 }
 
+def get_closest_m(M):
+    allowed_m_values = [1, 2, 4, 8, 16, 32, 64, 128]  # Add or modify as needed
+    return min(allowed_m_values, key=lambda x: abs(x - M))
 
 # Triton
 class GemLiteLinearTriton(torch.nn.Module):
@@ -310,7 +313,7 @@ class GemLiteLinearTriton(torch.nn.Module):
             self.acc_dtype,
         ]
 
-        _signature = (x_input.shape[0],) + self.signature
+        _signature = (get_closest_m(x_input.shape[0]),) + self.signature
         if _signature not in GEMLITE_TRITON_CACHE:
             self.warmup(_signature, args)
 

--- a/gemlite/triton_kernels/gemm_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_A16fWnO16f_int32packing.py
@@ -49,11 +49,7 @@ def get_gemm_config():
                                 )
     return _configs
 
-def get_closest_m(M):
-    allowed_m_values = [8, 16, 32, 64, 128]  # Add or modify as needed
-    return min(allowed_m_values, key=lambda x: abs(x - M))
-
-@triton.heuristics({'CLOSEST_M': lambda args: get_closest_m(args['M'])})
+@triton.heuristics(values={'CLOSEST_M': lambda args: 2 ** int(math.ceil(math.log2(args['M'])))})
 @triton.autotune(
     configs = get_gemm_config(),
     key=['CLOSEST_M', 'N', 'K', 'group_size', 'W_nbits'],

--- a/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
@@ -51,14 +51,9 @@ def get_gemv_config():
 
     return _configs
 
-def get_closest_m(M):
-    allowed_m_values = [1, 2, 4, 8]  # Add or modify as needed
-    return min(allowed_m_values, key=lambda x: abs(x - M))
-
-@triton.heuristics({'CLOSEST_M': lambda args: get_closest_m(args['M'])})
 @triton.autotune(
     configs = get_gemv_config(),
-    key=['CLOSEST_M', 'N', 'K', 'group_size', 'W_nbits'],
+    key=['M', 'N', 'K', 'group_size', 'W_nbits'],
     prune_configs_by={
         'early_config_prune': kernel_config_pruner,
     },
@@ -77,7 +72,6 @@ def gemv_A16fWnO16f_int32packing_kernel(
     stride_cm, stride_cn,
     stride_meta, 
     acc_dtype: tl.constexpr,
-    CLOSEST_M: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr
 ):
     """

--- a/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
@@ -51,9 +51,14 @@ def get_gemv_config():
 
     return _configs
 
+def get_closest_m(M):
+    allowed_m_values = [1, 2, 4, 8]  # Add or modify as needed
+    return min(allowed_m_values, key=lambda x: abs(x - M))
+
+@triton.heuristics({'CLOSEST_M': lambda args: get_closest_m(args['M'])})
 @triton.autotune(
     configs = get_gemv_config(),
-    key=['M', 'N', 'K', 'group_size', 'W_nbits'],
+    key=['CLOSEST_M', 'N', 'K', 'group_size', 'W_nbits'],
     prune_configs_by={
         'early_config_prune': kernel_config_pruner,
     },
@@ -72,6 +77,7 @@ def gemv_A16fWnO16f_int32packing_kernel(
     stride_cm, stride_cn,
     stride_meta, 
     acc_dtype: tl.constexpr,
+    CLOSEST_M: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr
 ):
     """


### PR DESCRIPTION
triton.autotune will tune for any change in one of the key values. Currently 'M' is also included as a key value, instead we can find the closest from a list of predefined M values and expose it as a meta parameter via triton.heuristics. 