### PR TITLE
 Add custom Triton configs and Python 3.12 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# python stuff
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.pyw
+*.pyz
+
+# pip stuff
+*.egg-info
+*.dist-info
+*.whl
+*.tar.gz
+*.zip

--- a/gemlite/triton_kernels/config.py
+++ b/gemlite/triton_kernels/config.py
@@ -1,8 +1,8 @@
 # Written by Dr. Hicham Badri @Mobius Labs GmbH - 2024
 # ********************************************************
-import sys,json
+import sys
 if sys.version_info < (3, 12): import imp
-else:  						   import importlib as imp
+else: import importlib as imp
 
 class AUTOTUNE_ENABLE:
 	GEMV           = True

--- a/gemlite/triton_kernels/config.py
+++ b/gemlite/triton_kernels/config.py
@@ -1,6 +1,8 @@
 # Written by Dr. Hicham Badri @Mobius Labs GmbH - 2024
 # ********************************************************
-import imp 
+import sys,json
+if sys.version_info < (3, 12): import imp
+else:  						   import importlib as imp
 
 class AUTOTUNE_ENABLE:
 	GEMV           = True

--- a/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
@@ -8,6 +8,7 @@ import triton.language as tl
 from .config import AUTOTUNE_ENABLE
 from . import utils
 from .utils import DTYPE_TO_TORCH, DTYPE_TO_TRITON, init_to_zero, is_divisible, swizzle_tile, linear_tile, dequantize
+from .triton_configs import AUTOTUNE_CONFIG
 
 KEYS        = ['M_CLOSEST', 'N', 'K', 'group_size', 'elements_per_sample'] 
 MATMUL_TYPE = "GEMM_SPLITK"
@@ -152,16 +153,6 @@ def get_default_config():
     return [config]
 
 ENABLE_AUTOTUNE = AUTOTUNE_ENABLE.GEMM_SPLITK
-
-@triton.autotune(
-    configs=get_autotune_config() if ENABLE_AUTOTUNE else get_default_config(),
-    key = KEYS,
-    prune_configs_by = {'early_config_prune': kernel_config_pruner} if ENABLE_AUTOTUNE else None,
-    warmup = 50, 
-    rep = 50,
-    use_cuda_graph = AUTOTUNE_ENABLE.USE_CUDA_GRAPH,
-)
-
 
 @triton.jit
 def gemm_splitK_A16fWnO16f_int32packing_kernel(
@@ -348,8 +339,22 @@ def gemm_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
     output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
     
     grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), META['SPLIT_K'])
+    config = AUTOTUNE_CONFIG.GEMM_SPLITK.get((M, N, K, group_size, elements_per_sample), None)
+    if config is None:
+        config = get_autotune_config() if ENABLE_AUTOTUNE else get_default_config()
+        try: import triton_dejavu; _autotune_fn = triton_dejavu.autotune
+        except: _autotune_fn = triton.autotune
+    else: _autotune_fn = triton.autotune
+    autotune_fn = _autotune_fn(
+            configs = config,
+            key = KEYS, 
+            prune_configs_by = {'early_config_prune': kernel_config_pruner} if ENABLE_AUTOTUNE else None,
+            warmup = 50, 
+            rep = 50,
+            use_cuda_graph = AUTOTUNE_ENABLE.USE_CUDA_GRAPH,
+        )
 
-    gemm_splitK_A16fWnO16f_int32packing_kernel[grid](
+    autotune_fn(gemm_splitK_A16fWnO16f_int32packing_kernel)[grid](
         x, W_q, output,
         scales, zeros, scales_x,
         M, N, K, M_CLOSEST,

--- a/gemlite/triton_kernels/triton_configs.py
+++ b/gemlite/triton_kernels/triton_configs.py
@@ -1,0 +1,16 @@
+import triton
+from .utils import init_to_zero
+
+# You can add your own configs here
+GEMM = {}
+GEMM_SPLITK = {}
+GEMV_REVSPLITK = {}
+GEMV = {}
+GEMV_SPLITK = {}
+
+class AUTOTUNE_CONFIG:
+	GEMV           = GEMV
+	GEMV_REVSPLITK = GEMV_REVSPLITK
+	GEMV_SPLITK    = GEMV_SPLITK
+	GEMM_SPLITK    = GEMM_SPLITK
+	GEMM           = GEMM


### PR DESCRIPTION
 This PR introduces several improvements to the Triton kernel configurations:

 - Add support for custom Triton configs through new `triton_configs.py`
 - Fix importlib compatibility for Python 3.12
 - Add .gitignore file for better repository management

 Changes include:
 - New file: gemlite/triton_kernels/triton_configs.py
 - Modified kernel files to support custom configurations:
   - gemm_A16fWnO16f_int32packing.py
   - gemm_splitK_A16fWnO16f_int32packing.py
   - gemv_revsplitK_A16fWnO16f_int32packing.py

1) Added import of AUTOTUNE_CONFIG from .triton_configs
```python 
from .triton_configs import AUTOTUNE_CONFIG
```

2) Removed the global `@triton.autotune` decorator from the kernel function. Instead added dynamic autotuning configuration in the forward function:

 • Checks for pre-configured settings in AUTOTUNE_CONFIG
 • Falls back to default/autotune config if no pre-configured setting exists
 • Attempts to use `triton_dejavu.autotune` if available, falls back to `triton.autotune`
 • Applies the autotuning configuration dynamically before kernel execution

 4 Modified kernel execution to use the dynamic autotuning:
 e.g. `autotune_fn(gemm_A16fWnO16f_int32packing_kernel)[grid]`

**Using pretuned custom triton configs can result in up to 30% improvements in latency. It also fixes the cold startup problem with vLLM server which profiles the model at the start. Tested with 4090 using Qwen models with bs > 1 up to 8.**

An example user modified `triton_configs.py`:

```python
import triton
from .utils import init_to_zero

GEMM =  {
	(128, 5120, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 8, 'A_load_order': 2, 'meta_evict_policy': ''}, num_warps=4, num_stages=1)],
	(128, 5120, 13824, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 8, 'A_load_order': 2, 'meta_evict_policy': ''}, num_warps=4, num_stages=1)],
	(128, 5120, 27648, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 8, 'A_load_order': 2, 'meta_evict_policy': ''}, num_warps=4, num_stages=1)],
	(128, 7168, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 128, 
...
}

GEMM_SPLITK =  {
	(2, 5120, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 8, 'SPLIT_K': 4, 'A_load_order': 2, 'meta_evict_policy': '', 'atomic_mode': 'relaxed'}, num_warps=4, num_stages=1, pre_hook=init_to_zero("c_ptr"))],
	(2, 5120, 13824, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 8, 'SPLIT_K': 4, 'A_load_order': 2, 'meta_evict_policy': '', 'atomic_mode': 'relaxed'}, num_warps=4, num_stages=1, pre_hook=init_to_zero("c_ptr"))],
...
	(64, 27648, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8, 'SPLIT_K': 2, 'A_load_order': 2, 'meta_evict_policy': '', 'atomic_mode': 'relaxed'}, num_warps=4, num_stages=1, pre_hook=init_to_zero("c_ptr"))],
	(64, 55296, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8, 'SPLIT_K': 2, 'A_load_order': 2, 'meta_evict_policy': '', 'atomic_mode': 'relaxed'}, num_warps=4, num_stages=1, pre_hook=init_to_zero("c_ptr"))]
}

GEMV_REVSPLITK = {
	(1, 5120, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 1, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'A_load_order': 0, 'meta_evict_policy': '', 'atomic_mode': 'relaxed', 'dot_prod_mode': 0}, num_warps=2, num_stages=2, pre_hook=init_to_zero("c_ptr"))],
	(1, 5120, 13824, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 1, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 16, 'A_load_order': 0, 'meta_evict_policy': '', 'atomic_mode': 'relaxed', 'dot_prod_mode': 0}, num_warps=2, num_stages=1, pre_hook=init_to_zero("c_ptr"))],
	(1, 5120, 27648, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 1, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'A_load_order': 0, 'meta_evict_policy': '', 'atomic_mode': 'relaxed', 'dot_prod_mode': 0}, num_warps=2, num_stages=1, pre_hook=init_to_zero("c_ptr"))],
...
	(1, 55296, 5120, 128, 8) : [triton.Config({'BLOCK_SIZE_M': 1, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'A_load_order': 1, 'meta_evict_policy': '', 'atomic_mode': 'relaxed', 'dot_prod_mode': 0}, num_warps=2, num_stages=1, pre_hook=init_to_zero("c_ptr"))]
}

GEMV = {}
GEMV_SPLITK = {}

class AUTOTUNE_CONFIG:
	GEMV           = GEMV
	GEMV_REVSPLITK = GEMV_REVSPLITK
	GEMV_SPLITK    = GEMV_SPLITK
	GEMM_SPLITK    = GEMM_SPLITK
	GEMM           = GEMM
```