### PR TITLE
Add bfloat16 support to gemlite kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ All kernels are flexible, supporting 8, 4, 2, and 1-bit weight precisions as wel
 ## Limitations
 * All kernels require a minimum group-size of 32.
 * <b><a href="https://github.com/mobiusml/gemlite/blob/master/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py">Gemv RevSplit-K</a></b>, which is the default kernel for batch-size=1, does not work with 1-bit weights packed as 32-bit with a group-size of 32. In this case, you should use 8-bit bitpacking via `.pack(...,packing_bitwidth=8)`, or revert to using the `GEMV` kernel instead.
-* On datacenter gpus (A100, H100, H200), 8-bit packing via `gemlite.set_packing_bitwidth(8)` is faster for larger batches.
+* On datacenter gpus (A100, H100, H200), 8-bit packing via `gemlite.set_packing_bitwidth(8)` is faster with larger batches.
+* `bfloat16` is about 5-7% slower for `1 <= M <= 64` because of the fp32 fallback atomic addition implementation. You can set the default gemv to the Split-K kernel which could run faster for `M == 1` in some cases depending on the GPU (A100 confirmed, but slower on the H100) `gemlite.core.get_default_gemv = lambda W_nbits: 'GEMM_SPLITK' if (W_nbits < 8) else 'GEMV_SPLITK'`.
 
 ## Performance
 ### End-2-End Performance

--- a/examples/benchmark_triton.py
+++ b/examples/benchmark_triton.py
@@ -19,9 +19,6 @@ except:
 from gemlite.core import GemLiteLinearTriton, DType, set_autotune, GEMLITE_ACC_DTYPE
 set_autotune({'GEMV_REVSPLITK':True, 'GEMV_SPLITK': True, 'GEMV':True, 'GEMM_SPLITK':True, 'GEMM':True}, exhaustive=True, use_cuda_graph=False)
 
-GEMLITE_ACC_DTYPE[DType.FP16] = DType.FP32 #For A100/H100
-#GEMLITE_ACC_DTYPE[DType.FP16] = DType.FP16 #For 3090/4090
-
 device = 'cuda:0'
 compute_dtype = torch.float16
 

--- a/examples/triton_hqq_example.py
+++ b/examples/triton_hqq_example.py
@@ -8,26 +8,28 @@ def check_valid(x, W, quant_linear, tol=1e-3):
 ############################################################################################
 from hqq.core.quantize import HQQLinear, BaseQuantizeConfig
 
-in_features, out_features = 4096*4, 4096*2
+in_features, out_features = 4096*4, 4096*4
 #W_nbits, group_size = 8, in_features 
-W_nbits, group_size = 4, 128 
-#W_nbits, group_size = 2, 128
+W_nbits, group_size = 4, 64 
+#W_nbits, group_size = 2, 64
+compute_dtype = torch.float16 #float16 / bfloat16
 
 linear       = torch.nn.Linear(in_features=in_features, out_features=out_features, bias=False, device='cpu')
 quant_config = BaseQuantizeConfig(nbits=W_nbits, group_size=group_size, quant_zero=False, quant_scale=False, axis=1)
-hqq_layer    = HQQLinear(linear, quant_config=quant_config, compute_dtype=torch.float16, device='cuda:0', del_orig=False) 
+hqq_layer    = HQQLinear(linear, quant_config=quant_config, compute_dtype=compute_dtype, device='cuda:0', del_orig=False) 
 
 orig_shape   = (out_features, in_features)
 W            = hqq_layer.dequantize().reshape(orig_shape)
 ############################################################################################
 
-from gemlite.core import GemLiteLinearTriton, DType
+from gemlite.core import GemLiteLinearTriton, DType, TORCH_TO_DTYPE
+gemlite_dtype = TORCH_TO_DTYPE[compute_dtype]
 gemlite_linear = GemLiteLinearTriton(W_nbits, 
                                     group_size=group_size, 
                                     in_features=in_features, 
                                     out_features=out_features, 
-                                    input_dtype=DType.FP16, 
-                                    output_dtype=DType.FP16)
+                                    input_dtype=gemlite_dtype, 
+                                    output_dtype=gemlite_dtype)
 
 W_q           = hqq_layer.unpack(dtype=torch.uint8).view(orig_shape)
 scales        = hqq_layer.meta['scale']

--- a/gemlite/__init__.py
+++ b/gemlite/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __author__  = 'Dr. Hicham Badri'
 __credits__ = 'Mobius Labs GmbH'
 

--- a/gemlite/dtypes.py
+++ b/gemlite/dtypes.py
@@ -25,6 +25,18 @@ DTYPE_TO_TORCH = {
     8: torch.float8_e5m2,
 }
 
+TORCH_TO_DTYPE = {
+    torch.float32: DType.FP32,
+    torch.float16: DType.FP16,
+    torch.bfloat16: DType.BF16,
+    torch.float8_e4m3fn: DType.FP8,
+    torch.int8: DType.INT8,
+    torch.uint8: DType.UINT8,
+    torch.int32: DType.INT32,
+    torch.uint32: DType.UINT32,
+    torch.float8_e5m2: DType.FP8e5,
+}
+
 TORCH_DTYPE_TO_TRITON = {
     torch.float16:       tl.float16,
     torch.float32:       tl.float32,

--- a/gemlite/helper.py
+++ b/gemlite/helper.py
@@ -37,7 +37,6 @@ class A16W8:
 
         gemlite_linear.W_group_mode       = 2
         gemlite_linear.channel_scale_mode = 0
-        gemlite_linear.default_gemv       = 'GEMV_SPLITK'
         return gemlite_linear
 
     def from_linear(self, linear_layer):
@@ -94,7 +93,6 @@ class A8W8_dynamic:
         gemlite_linear.W_group_mode       = 0
         gemlite_linear.channel_scale_mode = 3 #activation[:,None] + weight[None,:]
         gemlite_linear.meta_dtype         = DType.FP32
-        gemlite_linear.default_gemv       = 'GEMV_SPLITK'
         return gemlite_linear
 
     def from_linear(self, linear_layer):
@@ -145,8 +143,6 @@ class A16Wn:
                             bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=True,
                             ) 
-
-        gemlite_linear.default_gemv = 'GEMV_REVSPLITK' 
 
         if(group_size == in_features):
             if(self.post_scale):
@@ -224,8 +220,6 @@ class A8Wn_dynamic(A16Wn):
             return out_x.view(x_shape), scaled_x
 
         gemlite_linear.scale_activations = scale_fct
-
-        gemlite_linear.default_gemv = 'GEMV_REVSPLITK' 
 
         if(group_size == in_features):
             if(self.post_scale):

--- a/gemlite/helper.py
+++ b/gemlite/helper.py
@@ -3,7 +3,7 @@
 
 import torch, gc
 from tqdm import tqdm
-from gemlite.core import GemLiteLinearTriton, DType, GEMLITE_ACC_DTYPE
+from gemlite.core import GemLiteLinearTriton, DType, GEMLITE_ACC_DTYPE, TORCH_TO_DTYPE
 
 ####################################################################################################
 #16-bit activations / 8-bit weigths
@@ -11,12 +11,14 @@ class A16W8:
     def __init__(self, device='cuda:0'):
         self.device = device
 
-    def from_weights(self, weight, bias):
-        #GEMLITE_ACC_DTYPE[DType.FP16] = DType.FP32
+    def from_weights(self, weight, bias=None):
+        assert weight.dtype in [torch.float16, torch.bfloat16, torch.float32], "Invalid weight.dtype, should floating point."
+        dtype = weight.dtype
+        gemlite_dtype = TORCH_TO_DTYPE[dtype]
 
         scales = torch.abs(weight.float()).amax(axis=1, keepdim=True) / 127.0
         W_q    = torch.round(weight / scales).to(device=self.device, dtype=torch.int8)
-        scales = scales.to(device=self.device, dtype=torch.float16)
+        scales = scales.to(device=self.device, dtype=dtype)
 
         in_features, out_features = weight.shape[::-1]
 
@@ -24,13 +26,13 @@ class A16W8:
                         group_size=in_features, 
                         in_features=in_features, 
                         out_features=out_features, 
-                        input_dtype=DType.FP16, 
-                        output_dtype=DType.FP16, 
+                        input_dtype=gemlite_dtype, 
+                        output_dtype=gemlite_dtype, 
                         )
 
         gemlite_linear.pack(W_q, scales, 
                             zeros=None, 
-                            bias=bias.to(device=self.device, dtype=torch.float16) if bias is not None else None, 
+                            bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=False)
 
         gemlite_linear.W_group_mode       = 2
@@ -49,17 +51,20 @@ class A8W8_dynamic:
         self.fp8 = fp8
         self.weight_scale = weight_scale
 
-    def from_weights(self, weight, bias):
+    def from_weights(self, weight, bias=None):
         if(self.fp8): #FP8
             w_dtype, input_dtype, max_val = torch.float8_e4m3fn, DType.FP8, 448
         else: #INT8
             w_dtype, input_dtype, max_val = torch.int8, DType.INT8, 127
 
+        assert weight.dtype in [torch.float16, torch.bfloat16, torch.float32], "Invalid weight.dtype, should floating point."
+        dtype = weight.dtype
+        gemlite_dtype = TORCH_TO_DTYPE[dtype]
         
         weight = weight.float() * self.weight_scale
         scales = torch.abs(weight).amax(axis=1, keepdim=True) / max_val
         W_q    = torch.round(weight / scales).to(device=self.device, dtype=w_dtype)
-        scales = scales.to(device=self.device, dtype=torch.float16)#.float()
+        scales = scales.to(device=self.device, dtype=dtype)#.float()
 
         in_features, out_features = weight.shape[::-1]
 
@@ -68,7 +73,7 @@ class A8W8_dynamic:
                         in_features=in_features, 
                         out_features=out_features, 
                         input_dtype=input_dtype,
-                        output_dtype=DType.FP16,
+                        output_dtype=gemlite_dtype,
                         scaled_activations=True,
                         )
 
@@ -83,7 +88,7 @@ class A8W8_dynamic:
 
         gemlite_linear.pack(W_q, scales / self.weight_scale, 
                             zeros=None, 
-                            bias=bias.to(device=self.device, dtype=torch.float16) if bias is not None else None, 
+                            bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=False)
         
         gemlite_linear.W_group_mode       = 0
@@ -116,23 +121,28 @@ class A16Wn:
         self.post_scale = post_scale
         self.device     = device
 
-    def from_weights(self, W_q, scales, zeros, W_nbits, group_size, bias):
+    def from_weights(self, W_q, scales, zeros, W_nbits, group_size, bias=None):
+
+        assert scales.dtype in [torch.float16, torch.bfloat16, torch.float32], "Invalid scales.dtype, should floating point."
+        dtype = scales.dtype
+        gemlite_dtype = TORCH_TO_DTYPE[dtype]
+
         in_features, out_features = W_q.shape[::-1]
 
         gemlite_linear = GemLiteLinearTriton(W_nbits, 
                         group_size=group_size,  
                         in_features=in_features, 
                         out_features=out_features, 
-                        input_dtype=DType.FP16, 
-                        output_dtype=DType.FP16, 
+                        input_dtype=gemlite_dtype, 
+                        output_dtype=gemlite_dtype, 
                         scaled_activations=False,
                         )
 
 
         gemlite_linear.pack(W_q.to(self.device), 
-                            scales.to(device=self.device, dtype=torch.float16), 
-                            zeros.to(device=self.device, dtype=torch.float16), 
-                            bias=bias.to(device=self.device, dtype=torch.float16) if bias is not None else None, 
+                            scales.to(device=self.device, dtype=dtype), 
+                            zeros.to(device=self.device, dtype=dtype), 
+                            bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=True,
                             ) 
 
@@ -181,7 +191,11 @@ class A8Wn_dynamic(A16Wn):
         self.post_scale = post_scale
         self.device     = device
 
-    def from_weights(self, W_q, scales, zeros, W_nbits, group_size, bias):
+    def from_weights(self, W_q, scales, zeros, W_nbits, group_size, bias=None):
+        assert scales.dtype in [torch.float16, torch.bfloat16, torch.float32], "Invalid scales.dtype, should floating point."
+        dtype = scales.dtype
+        gemlite_dtype = TORCH_TO_DTYPE[dtype]
+
         w_dtype, input_dtype, max_val = torch.float8_e4m3fn, DType.FP8, 448
 
         in_features, out_features = W_q.shape[::-1]
@@ -191,14 +205,14 @@ class A8Wn_dynamic(A16Wn):
                         in_features=in_features, 
                         out_features=out_features, 
                         input_dtype=input_dtype, 
-                        output_dtype=DType.FP16,
+                        output_dtype=gemlite_dtype,
                         scaled_activations=True,
                         )
 
         gemlite_linear.pack(W_q.to(self.device), 
-                            scales.to(device=self.device, dtype=torch.float16), 
-                            zeros.to(device=self.device, dtype=torch.float16), 
-                            bias=bias.to(device=self.device, dtype=torch.float16) if bias is not None else None, 
+                            scales.to(device=self.device, dtype=dtype), 
+                            zeros.to(device=self.device, dtype=dtype), 
+                            bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=True,
                             ) 
 
@@ -226,7 +240,7 @@ class A8Wn_dynamic(A16Wn):
 
 ####################################################################################################
 #Warm-up function: 
-def warmup(shapes: list, batch_sizes: list = [2**i for i in range(0,11)], W_nbits: list = [8, 4], group_sizes: list = [64], mode: str = 'static'):
+def warmup(shapes: list, batch_sizes: list = [2**i for i in range(0,11)], W_nbits: list = [8, 4], group_sizes: list = [64], mode: str = 'static', dtype = torch.float16):
     """
     * Warm-up for A16W4 with group_size=64
     warmup(shapes=[(4096, 4096)], W_nbits=[4], group_sizes=[64], mode='static')
@@ -249,7 +263,7 @@ def warmup(shapes: list, batch_sizes: list = [2**i for i in range(0,11)], W_nbit
             for shape in shapes:
                 for batch_size in tqdm(batch_sizes):
                     out_features, in_features = shape
-                    linear = torch.nn.Linear(in_features=in_features, out_features=out_features, bias=False, dtype=torch.float16, device='cuda:0')
+                    linear = torch.nn.Linear(in_features=in_features, out_features=out_features, bias=False, dtype=dtype, device='cuda:0')
 
                     if(W_nbit == 8):
                         processor      = A16W8 if (mode == 'static') else (A8W8_fp8_dynamic if mode == 'dynamic_fp8' else A8W8_int8_dynamic)
@@ -257,11 +271,11 @@ def warmup(shapes: list, batch_sizes: list = [2**i for i in range(0,11)], W_nbit
                     else:
                         processor      = A16Wn if (mode == 'static') else A8Wn_dynamic
                         quant_config   = BaseQuantizeConfig(nbits=W_nbit, group_size=group_size, axis=1)
-                        linear         = HQQLinear(linear, quant_config=quant_config, compute_dtype=torch.float16, device='cuda:0')
+                        linear         = HQQLinear(linear, quant_config=quant_config, compute_dtype=dtype, device='cuda:0')
                         gemlite_linear = processor(device='cuda:0').from_hqqlinear(linear)
 
 
-                    _ = gemlite_linear(torch.randn((batch_size, in_features), dtype=torch.float16, device='cuda:0') / 100.)
+                    _ = gemlite_linear(torch.randn((batch_size, in_features), dtype=dtype, device='cuda:0') / 100.)
 
                     del linear, gemlite_linear
                     torch.cuda.empty_cache()

--- a/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
@@ -197,8 +197,6 @@ def gemm_splitK_A16fWnO16f_int32packing_kernel(
     GROUP_SIZE_M: tl.constexpr, SPLIT_K: tl.constexpr,
     A_load_order: tl.constexpr, meta_evict_policy: tl.constexpr, atomic_mode: tl.constexpr,
     data_contiguous: tl.constexpr,
-    native_atomic: tl.constexpr = True, #Use native atomic addition
-    Lock = None, #Lock for atomic cas
 ):
     """
     Based on https://github.com/foundation-model-stack/foundation-model-stack/blob/triton/triton/kernels/gptq/splitk_dequant_gemm.py
@@ -323,9 +321,7 @@ def gemm_splitK_A16fWnO16f_int32packing_kernel(
         scales_b = tl.load(scales_ptr   + offs_bn, mask=offs_bn < N, other=1, eviction_policy=meta_evict_policy)
         acc      = acc.to(meta_dtype) * (scales_a[:, None] * scales_b[None, :])
 
-    acc = acc.to(output_dtype)
     ##################################################################
-
     #Output
     offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
@@ -334,10 +330,7 @@ def gemm_splitK_A16fWnO16f_int32packing_kernel(
     mask    = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
 
     if(SPLIT_K > 1):
-        if(native_atomic):
-            tl.atomic_add(c_ptrs, acc, mask=mask, sem=atomic_mode) #release / relaxed
-        else:
-            atomic_add_cas(c_ptrs, acc, Lock, mask=mask, sem=atomic_mode)
+        tl.atomic_add(c_ptrs, acc, mask=mask, sem=atomic_mode) 
     else:
         tl.store(c_ptrs, acc, mask=mask) 
 
@@ -352,17 +345,12 @@ def gemm_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
                                                 ) -> Tensor: 
     
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
+    #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
 
     M_CLOSEST = utils.get_closest_m(M)
 
-    #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
-    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-
-    native_atomic = output_dtype in [DType.FP16, DType.FP32]
-    if(native_atomic):
-        Lock = None
-    else:
-        Lock = torch.zeros((1,), device=W_q.device, dtype=torch.int32)
+    native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32)
     
     grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), META['SPLIT_K'])
 
@@ -375,19 +363,20 @@ def gemm_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
         W_q.stride(0), W_q.stride(1),
         output.stride(0), output.stride(1),
         scales.stride(0), scales.stride(1),
-        ########################
+        ################################################
         input_dtype  = DTYPE_TO_TRITON[input_dtype],
         output_dtype = DTYPE_TO_TRITON[output_dtype],
         acc_dtype    = DTYPE_TO_TRITON[acc_dtype],
         meta_dtype   = DTYPE_TO_TRITON[meta_dtype],
-        ########################
+        ################################################
         channel_scale_mode = channel_scale_mode,
         W_group_mode       = W_group_mode,
         zero_is_scalar     = zeros.numel() == 1,
         data_contiguous    = data_contiguous,
-        native_atomic      = native_atomic,
-        Lock               = Lock,
     )
+
+    if(not native_atomic):
+        output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
 

--- a/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
@@ -173,6 +173,8 @@ def gemv_A16fWnO16f_int32packing_kernel(
     A_load_order: tl.constexpr, meta_evict_policy : tl.constexpr, atomic_mode: tl.constexpr, dot_prod_mode:tl.constexpr,
     data_contiguous: tl.constexpr,
     dump_b_val: tl.constexpr = 0, #Improve accuracy mainly for A16W8 with post looop scaling
+    native_atomic: tl.constexpr = True, #Use native atomic addition
+    Lock = None, #Lock for atomic cas
 ):
     """
     GEMV for C = matmul(A, dequantize(B, scales, zeros)). This is optimized for M==1
@@ -277,8 +279,11 @@ def gemv_A16fWnO16f_int32packing_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_cn = tl.max_contiguous(tl.multiple_of(offs_cn, BLOCK_SIZE_N), BLOCK_SIZE_N)
     c_ptrs  = c_ptr + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
-    tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
 
+    if(native_atomic):
+        tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
+    else:
+        atomic_add_cas(c_ptrs, acc, Lock, sem=atomic_mode)
 
 _costum_op_id = '_' + str(int(random.random()*10000))
 
@@ -293,7 +298,13 @@ def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
 
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
     output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-    
+
+    native_atomic = output_dtype in [DType.FP16, DType.FP32]
+    if(native_atomic):
+        Lock = None
+    else:
+        Lock = torch.zeros((1,), device=W_q.device, dtype=torch.int32)
+
     grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE_M']) * triton.cdiv(N, meta['BLOCK_SIZE_N']), triton.cdiv(K, meta['BLOCK_SIZE_K']))
 
     gemv_A16fWnO16f_int32packing_kernel[grid](
@@ -305,17 +316,19 @@ def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
         W_q.stride(0), W_q.stride(1),
         output.stride(0), output.stride(1),
         scales.stride(0), scales.stride(1),
-        ########################
+        ############################################
         input_dtype  = DTYPE_TO_TRITON[input_dtype],
         output_dtype = DTYPE_TO_TRITON[output_dtype],
         acc_dtype    = DTYPE_TO_TRITON[acc_dtype],
         meta_dtype   = DTYPE_TO_TRITON[meta_dtype],
-        ########################
+        ############################################
         channel_scale_mode = channel_scale_mode,
         W_group_mode       = W_group_mode,
         zero_is_scalar     = zeros.numel() == 1,
         data_contiguous    = data_contiguous,
         dump_b_val         = 0.001 if(W_group_mode in [0, 1] and acc_dtype == DType.FP16.value and W_nbits == 8) else 0, #Warning: Only use with INT8
+        native_atomic      = native_atomic,
+        Lock               = Lock,
     )
 
     return output

--- a/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
@@ -173,8 +173,6 @@ def gemv_A16fWnO16f_int32packing_kernel(
     A_load_order: tl.constexpr, meta_evict_policy : tl.constexpr, atomic_mode: tl.constexpr, dot_prod_mode:tl.constexpr,
     data_contiguous: tl.constexpr,
     dump_b_val: tl.constexpr = 0, #Improve accuracy mainly for A16W8 with post looop scaling
-    native_atomic: tl.constexpr = True, #Use native atomic addition
-    Lock = None, #Lock for atomic cas
 ):
     """
     GEMV for C = matmul(A, dequantize(B, scales, zeros)). This is optimized for M==1
@@ -279,11 +277,8 @@ def gemv_A16fWnO16f_int32packing_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_cn = tl.max_contiguous(tl.multiple_of(offs_cn, BLOCK_SIZE_N), BLOCK_SIZE_N)
     c_ptrs  = c_ptr + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
+    tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
 
-    if(native_atomic):
-        tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
-    else:
-        atomic_add_cas(c_ptrs, acc, Lock, sem=atomic_mode)
 
 _costum_op_id = '_' + str(int(random.random()*10000))
 
@@ -295,15 +290,10 @@ def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
                                          ) -> Tensor:
 
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
-    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-
-    native_atomic = output_dtype in [DType.FP16, DType.FP32]
-    if(native_atomic):
-        Lock = None
-    else:
-        Lock = torch.zeros((1,), device=W_q.device, dtype=torch.int32)
+    
+    native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32)
 
     grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE_M']) * triton.cdiv(N, meta['BLOCK_SIZE_N']), triton.cdiv(K, meta['BLOCK_SIZE_K']))
 
@@ -327,9 +317,10 @@ def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
         zero_is_scalar     = zeros.numel() == 1,
         data_contiguous    = data_contiguous,
         dump_b_val         = 0.001 if(W_group_mode in [0, 1] and acc_dtype == DType.FP16.value and W_nbits == 8) else 0, #Warning: Only use with INT8
-        native_atomic      = native_atomic,
-        Lock               = Lock,
     )
+
+    if(not native_atomic):
+        output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
 

--- a/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
@@ -184,8 +184,6 @@ def gemv_revsplitK_A16fWnO16f_int32packing_kernel(
     A_load_order: tl.constexpr, meta_evict_policy : tl.constexpr, atomic_mode: tl.constexpr, dot_prod_mode: tl.constexpr,
     data_contiguous: tl.constexpr,
     dump_b_val: tl.constexpr = 0, #Improve accuracy mainly for A16W8 with post looop scaling
-    native_atomic: tl.constexpr = True, #Use native atomic addition
-    Lock = None, #Lock for atomic cas
 ):
     """
     GEMV for C = matmul(A, dequantize(B, scales, zeros)). This is optimized for M==1
@@ -299,19 +297,14 @@ def gemv_revsplitK_A16fWnO16f_int32packing_kernel(
         scales_b = tl.load(scales_ptr   + offs_bn, mask=offs_bn < N, other=1, eviction_policy=meta_evict_policy)
         acc      = acc.to(meta_dtype) * (scales_a[:, None] * scales_b[None, :])
 
-    acc = acc.to(output_dtype)
     ##################################################################
-
     #Output: tl.atomic_add only supports 1D fp16 arrays, bfp16 would crash 
     offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_cn = tl.max_contiguous(tl.multiple_of(offs_cn, BLOCK_SIZE_N), BLOCK_SIZE_N)
     c_ptrs  = c_ptr + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
+    tl.atomic_add(c_ptrs, acc, sem=atomic_mode)
 
-    if(native_atomic):
-        tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
-    else:
-        atomic_add_cas(c_ptrs, acc, Lock, sem=atomic_mode)
 
 _costum_op_id = '_' + str(int(random.random()*10000))
 
@@ -323,15 +316,10 @@ def gemv_revsplitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scale
                                                    ) -> Tensor:
 
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
-    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
 
-    native_atomic = output_dtype in [DType.FP16, DType.FP32]
-    if(native_atomic):
-        Lock = None
-    else:
-        Lock = torch.zeros((1,), device=W_q.device, dtype=torch.int32)
+    native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32)
     
     grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE_M']) * triton.cdiv(N, meta['BLOCK_SIZE_N']), triton.cdiv(K, meta['BLOCK_SIZE_K'] * 2))
 
@@ -344,20 +332,21 @@ def gemv_revsplitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scale
         W_q.stride(0), W_q.stride(1),
         output.stride(0), output.stride(1),
         scales.stride(0), scales.stride(1),
-        ########################
+        ################################################
         input_dtype  = DTYPE_TO_TRITON[input_dtype],
         output_dtype = DTYPE_TO_TRITON[output_dtype],
         acc_dtype    = DTYPE_TO_TRITON[acc_dtype],
         meta_dtype   = DTYPE_TO_TRITON[meta_dtype],
-        ########################
+        ################################################
         channel_scale_mode = channel_scale_mode,
         W_group_mode       = W_group_mode,
         zero_is_scalar     = zeros.numel() == 1,
         data_contiguous    = data_contiguous,
-        dump_b_val         = 0.001 if(W_group_mode in [0, 1] and acc_dtype == DType.FP16.value and W_nbits == 8) else 0, #Warning: Only use with INT8
-        native_atomic      = native_atomic,
-        Lock               = Lock,
+        dump_b_val         = 0.001 if(W_group_mode in [0, 1] and acc_dtype in [DType.FP16.value] and W_nbits == 8) else 0, #Warning: Only use with INT8
     )
+
+    if(not native_atomic):
+        output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
 

--- a/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
@@ -8,8 +8,9 @@ import triton.language as tl
 from .config import AUTOTUNE_ENABLE
 from .utils import *
 
-KEYS        = ['M', 'N', 'K', 'group_size', 'elements_per_sample']
-MATMUL_TYPE = "GEMV_REVSPLITK"
+KEYS          = ['M', 'N', 'K', 'group_size', 'elements_per_sample']
+MATMUL_TYPE   = "GEMV_REVSPLITK"
+NATIVE_ATOMIC = gpu_supports_bfloat16_atomicadd()
 
 def kernel_config_pruner(configs, nargs, **kwargs):
     global KEYS
@@ -318,7 +319,7 @@ def gemv_revsplitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scale
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
 
-    native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    native_atomic = (output_dtype in [DType.FP16.value, DType.FP32.value]) or NATIVE_ATOMIC
     output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32)
     
     grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE_M']) * triton.cdiv(N, meta['BLOCK_SIZE_N']), triton.cdiv(K, meta['BLOCK_SIZE_K'] * 2))

--- a/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
@@ -203,8 +203,6 @@ def gemv_splitK_A16fWnO16f_int32packing_kernel(
     A_load_order: tl.constexpr, meta_evict_policy: tl.constexpr, atomic_mode: tl.constexpr, dot_prod_mode: tl.constexpr,
     data_contiguous: tl.constexpr,
     dump_b_val: tl.constexpr = 0, #Improve accuracy mainly for A16W8 with post looop scaling
-    native_atomic: tl.constexpr = True, #Use native atomic addition
-    Lock = None, #Lock for atomic cas
 ):
     """
     Based on https://github.com/foundation-model-stack/foundation-model-stack/blob/triton/triton/kernels/gptq/splitk_dequant_gemm.py
@@ -338,7 +336,6 @@ def gemv_splitK_A16fWnO16f_int32packing_kernel(
         scales_b = tl.load(scales_ptr   + offs_bn, mask=offs_bn < N, other=1, eviction_policy=meta_evict_policy)
         acc      = acc.to(meta_dtype) * (scales_a[:, None] * scales_b[None, :])
 
-    acc = acc.to(output_dtype)
     ##################################################################
 
     #Output
@@ -351,10 +348,7 @@ def gemv_splitK_A16fWnO16f_int32packing_kernel(
     if(SPLIT_K == 1):
         tl.store(c_ptrs, acc, mask=mask) 
     else:
-        if(native_atomic):
-            tl.atomic_add(c_ptrs, acc, mask=mask, sem=atomic_mode) 
-        else:
-            atomic_add_cas(c_ptrs, acc, Lock, mask=mask, sem=atomic_mode)
+        tl.atomic_add(c_ptrs, acc, mask=mask, sem=atomic_mode) 
 
 
 _costum_op_id = '_' + str(int(random.random()*10000))
@@ -367,15 +361,13 @@ def gemv_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
                                                 ) -> Tensor: 
     
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
-    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
 
-    native_atomic = output_dtype in [DType.FP16, DType.FP32]
-    if(native_atomic):
-        Lock = None
-    else:
-        Lock = torch.zeros((1,), device=W_q.device, dtype=torch.int32)
+    native_atomic = True 
+    #native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    #WARNING: change this to the second check if SPLIT_K > 1 
+    
+    output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32) 
     
     grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), META['SPLIT_K'])
 
@@ -388,20 +380,21 @@ def gemv_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
         W_q.stride(0), W_q.stride(1),
         output.stride(0), output.stride(1),
         scales.stride(0), scales.stride(1),
-        ########################
+        ################################################
         input_dtype  = DTYPE_TO_TRITON[input_dtype],
         output_dtype = DTYPE_TO_TRITON[output_dtype],
         acc_dtype    = DTYPE_TO_TRITON[acc_dtype],
         meta_dtype   = DTYPE_TO_TRITON[meta_dtype],
-        ########################
+        ################################################
         channel_scale_mode = channel_scale_mode,
         W_group_mode       = W_group_mode,
         zero_is_scalar     = zeros.numel() == 1,
         data_contiguous    = data_contiguous,
         dump_b_val         = 0.001 if(W_group_mode in [0, 1] and acc_dtype == DType.FP16.value and W_nbits == 8) else 0, #Warning: Only use with INT8
-        native_atomic      = native_atomic,
-        Lock               = Lock,
     )
+
+    if(not native_atomic):
+        output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
 

--- a/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
@@ -8,8 +8,9 @@ import triton.language as tl
 from .config import AUTOTUNE_ENABLE
 from .utils import *
 
-KEYS        = ['M', 'N', 'K', 'group_size', 'elements_per_sample']
-MATMUL_TYPE = "GEMV_SPLITK"
+KEYS          = ['M', 'N', 'K', 'group_size', 'elements_per_sample']
+MATMUL_TYPE   = "GEMV_SPLITK"
+NATIVE_ATOMIC = gpu_supports_bfloat16_atomicadd()
 
 def kernel_config_pruner(configs, nargs, **kwargs):
     global KEYS
@@ -364,7 +365,7 @@ def gemv_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
     #assert K == W_q.shape[0] * elements_per_sample, "Invalid Input Shapes"
 
     native_atomic = True 
-    #native_atomic = output_dtype in [DType.FP16.value, DType.FP32.value]
+    #native_atomic = (output_dtype in [DType.FP16.value, DType.FP32.value]) or NATIVE_ATOMIC
     #WARNING: change this to the second check if SPLIT_K > 1 
     
     output = torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype] if native_atomic else torch.float32) 

--- a/gemlite/triton_kernels/utils.py
+++ b/gemlite/triton_kernels/utils.py
@@ -62,8 +62,9 @@ def gpu_has_more_shared_memory(ref_gpus = ['a100', 'h100', 'h200', 'h800', 'b100
     return True in [g in gpu_name for g in ref_gpus]
 
 def gpu_supports_bfloat16_atomicadd():
-    major, minor = torch.cuda.get_device_capability()
-    return major >= 9
+    #Triton tl.atomic_add doens't support bfloat16 even for Hopper and above. 
+    #return torch.cuda.get_device_capability()[0] >= 9 #Hopper and above
+    return False
 
 #Next power of 2
 M_MAXVAL  = 1024

--- a/gemlite/triton_kernels/utils.py
+++ b/gemlite/triton_kernels/utils.py
@@ -44,7 +44,7 @@ def dequantize(b, scales, zeros, q_shift, meta_dtype, unpack_mask, elements_per_
     return b
 
 @triton.jit
-def atomic_add_cas(ptr, value, Lock, mask=None, sem: tl.constexpr = 'release'):
+def atomic_add_cas(ptr, value, Lock, mask=None, sem: tl.constexpr = 'release'):    
     while tl.atomic_cas(Lock, 0, 1, sem=sem) == 1:
         pass
     tl.store(ptr, tl.load(ptr, mask=mask) + value, mask=mask)

--- a/gemlite/triton_kernels/utils.py
+++ b/gemlite/triton_kernels/utils.py
@@ -57,9 +57,13 @@ def init_to_zero(name):
 def is_divisible(dividend, divisor):
     return dividend % divisor == 0
 
-def gpu_has_more_shared_memory(ref_gpus = ['a100', 'h100', 'h200', 'h800']): 
+def gpu_has_more_shared_memory(ref_gpus = ['a100', 'h100', 'h200', 'h800', 'b100', 'b200']): 
     gpu_name = torch.cuda.get_device_properties(0).name.lower()
     return True in [g in gpu_name for g in ref_gpus]
+
+def gpu_supports_bfloat16_atomicadd():
+    major, minor = torch.cuda.get_device_capability()
+    return major >= 9
 
 #Next power of 2
 M_MAXVAL  = 1024

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from torch.utils.cpp_extension import BuildExtension
 
 setup(
     name='gemlite',
-    version="0.4.3",
+    version="0.4.4",
     url="https://github.com/mobiusml/gemlite/",
     author="Dr. Hicham Badri",
     author_email="hicham@mobiuslabs.com",


### PR DESCRIPTION
- [x] Enable bfloat16 `DType` in core.py.
- [x] Implement fallback fp32 atomic addition.
- [x] Update tests.
- [x] Update examples. 
- [x] Update Readme.
- [x] Test on non-Hopper (A100) and Hopper (H100)
- [x] Eval speed

Overall, the impact of the fp32 fallback atomic add is about 5-7% for batch-sizes between 1 and 64. The gemv kernels are more impacted since they run more atomic additions while the split-K kernel only runs `SPLIT_K` atomic additions. So the impact is basically on smaller batch-sizes.