### PR TITLE
Add support for vllm compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Extensive performance results across different bitwidths, batch sizes, and devic
 - [Contributing](#contributing)
 
 # Recent Highlights
+- GemLite now supports vLLM V1 (torch.compile compatible)!
 - GemLite now supports bfloat16!
 - GemLite is now available in <a href="https://github.com/vllm-project/vllm/">vllm</a> via the <a href="https://github.com/mobiusml/hqq/">hqq</a> lib! 
 - GemLite is now integrated with <a href="https://github.com/pytorch/ao">TorchAO</a>/<a href="https://github.com/sgl-project/sglang">SGLang</a> for 4-bit quantization. Check-out the <a href="https://pytorch.org/blog/accelerating-llm-inference/">blogpost</a>!
@@ -65,9 +66,6 @@ from gemlite import DType, GemLiteLinear
 #Reset the default cache to get the best perf but warm-up will be slow. 
 #gemlite.reset_cache()
 
-#Force fp16 acc (faster on consumer gpus - automatically set)
-#gemlite.set_acc_dtype(DType.FP16)
-
 #Main constructor
 gemlite_linear = GemLiteLinear(
     W_nbits, #weight quantization bitwidth. supported: [8, 4, 2, 1]
@@ -81,9 +79,6 @@ gemlite_linear = GemLiteLinear(
 
 #Packing: we follow the same format as hqq (https://github.com/mobiusml/hqq/)
 gemlite_linear.pack(W_q, scales, zeros, bias)
-
-#For activation quantization you need to override this function which should return the activation scales:
-#gemlite_linear.scale_activations = f(x: torch.Tensor) -> x_scaled: torch.Tensor, scales: torch.Tensor # x ~ x_scaled * scaled
 
 #Forward
 out = gemlite_linear(x)

--- a/gemlite/__init__.py
+++ b/gemlite/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __author__  = 'Dr. Hicham Badri'
 __credits__ = 'Mobius Labs GmbH'
 

--- a/gemlite/core.py
+++ b/gemlite/core.py
@@ -266,8 +266,9 @@ class GemLiteLinearTriton(torch.nn.Module):
         if W_nbits not in GemLiteLinearTriton.SUPPORTED_BITS_TRITON:
             raise NotImplementedError("Only " + str(GemLiteLinearTriton.SUPPORTED_BITS_TRITON) + " W_nbits are supported.")
 
-        if (in_features % GemLiteLinearTriton.MIN_SIZE != 0) or (in_features % group_size !=0 if (group_size is not None) else False):
-            raise NotImplementedError("Invalid input shapes: " + str(in_features) + ' , ' + str(out_features) + '. in_features should be divisible by 32 or the group_size')
+        if (in_features is not None and out_features is not None):
+            if (in_features % GemLiteLinearTriton.MIN_SIZE != 0) or (in_features % group_size !=0 if (group_size is not None) else False):
+                raise NotImplementedError("Invalid input shapes: " + str(in_features) + ' , ' + str(out_features) + '. in_features should be divisible by 32 or the group_size')
 
         #Warning: Input dtype should be the same as dequantize() weights dtype.
         if input_dtype not in GemLiteLinearTriton.SUPPORTED_DTYPES:

--- a/gemlite/core.py
+++ b/gemlite/core.py
@@ -8,6 +8,7 @@ import math, json, os
 import warnings, random
 from typing import List, Union, Tuple, Callable
 import logging
+from functools import partial
     
 #Dtypes
 from .dtypes import *
@@ -199,7 +200,7 @@ class GemLiteLinearTriton(torch.nn.Module):
                 max_val = torch.finfo(self.compute_dtype).max
             else:
                 max_val = torch.iinfo(self.compute_dtype).max
-            self.scale_activations = lambda x: scale_activations(x, w_dtype=self.compute_dtype, max_val=max_val)
+            self.scale_activations = partial(scale_activations, w_dtype=self.compute_dtype, max_val=max_val)
 
         #Default forward        
         self.forward = self.forward_auto_no_warmup
@@ -269,7 +270,7 @@ class GemLiteLinearTriton(torch.nn.Module):
 
         if W_q.dtype == torch.uint8:  # Packed weigths
             _pack_weights_over_cols = pack_weights_over_cols_triton if (W_q.device.type == "cuda") else pack_weights_over_cols_torch
-            
+
             self.W_q, self.elements_per_sample = _pack_weights_over_cols(
                 W_q.view(self.orig_shape),
                 W_nbits=self.W_nbits,

--- a/gemlite/dtypes.py
+++ b/gemlite/dtypes.py
@@ -12,6 +12,9 @@ class DType(Enum):
     INT32  = 6
     UINT32 = 7
     FP8e5  = 8
+    INT16  = 9
+    UINT16 = 10
+    INT64  = 11
 
 DTYPE_TO_TORCH = {
     0: torch.float32,
@@ -23,6 +26,9 @@ DTYPE_TO_TORCH = {
     6: torch.int32,
     7: torch.uint32,
     8: torch.float8_e5m2,
+    9: torch.int16,
+    10: torch.uint16,
+    11: torch.int64,
 }
 
 TORCH_TO_DTYPE = {
@@ -35,6 +41,9 @@ TORCH_TO_DTYPE = {
     torch.int32: DType.INT32,
     torch.uint32: DType.UINT32,
     torch.float8_e5m2: DType.FP8e5,
+    torch.int16: DType.INT16,
+    torch.uint16: DType.UINT16,
+    torch.int64: DType.INT64,
 }
 
 TORCH_DTYPE_TO_TRITON = {
@@ -49,6 +58,16 @@ TORCH_DTYPE_TO_TRITON = {
     torch.uint32:        tl.uint32,
     torch.float8_e4m3fn: tl.float8e4nv,
     torch.float8_e5m2:   tl.float8e5,
+    torch.int16:         tl.int16,
+    torch.uint16:        tl.uint16,
+    torch.int64:         tl.int64,
 }
 
 DTYPE_TO_TRITON = {k:TORCH_DTYPE_TO_TRITON[d] for k,d in DTYPE_TO_TORCH.items()}
+
+PACKING_BITWIDTH_TO_TORCH_DTYPE = {
+    8: torch.uint8,
+    16: torch.int16,
+    32: torch.int32,
+    64: torch.int64,
+}

--- a/gemlite/helper.py
+++ b/gemlite/helper.py
@@ -2,22 +2,87 @@
 #********************************************************
 
 import torch, gc
+from torch import Tensor
 from typing import Tuple
 from tqdm import tqdm
 from functools import partial
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
 from gemlite.core import GemLiteLinearTriton, DType, GEMLITE_ACC_DTYPE, TORCH_TO_DTYPE
 
-def scale_activations(x: torch.Tensor, w_dtype: torch.dtype, max_val: float, fp32_scale: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
+#Main activation scaling functions
+def scale_activations_torch(x: Tensor, w_dtype: torch.dtype, max_val: float, fp32_scale: bool = True) -> Tuple[Tensor, Tensor]:
     if(fp32_scale):
         x = x.to(dtype=torch.float32, copy=False)
     x_shape  = x.shape
     out_x    = x.view(-1, x.shape[-1]) 
     scales_x = torch.abs(out_x).amax(axis=1, keepdim=True)
     scales_x.div_(max_val)
-    out_x.div_(scales_x)
+    out_x = x / scales_x
     out_x.round_()    
     out_x = out_x.to(dtype=w_dtype)
     return out_x.view(x_shape), scales_x
+
+@triton.jit
+def scale_activations_kernel(
+    x_ptr, scale_ptr, y_ptr, 
+    M, K,
+    stride_m, stride_k, stride_sm,
+    max_val: tl.constexpr,
+    fp32_scale: tl.constexpr, 
+    BLOCK_M: tl.constexpr, 
+    BLOCK_K: tl.constexpr 
+):
+    pid_m = tl.program_id(0)
+    pid_k = tl.program_id(1)
+
+    offs_m  = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_k  = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+    mask    = ((offs_m < M)[:, None] & (offs_k < K)[None, :]).to(tl.int1)
+    in_ptrs = offs_m[:, None] * stride_m + offs_k[None, :] * stride_k
+
+    x = tl.load(x_ptr + in_ptrs, mask=mask, other=0.0)
+    if(fp32_scale):
+        x = x.to(tl.float32)
+
+    blk_max = tl.max(tl.abs(x), axis=1, keep_dims=True) / max_val
+
+    y = libdevice.round(x / blk_max)
+
+    tl.store(scale_ptr + offs_m[:, None] * stride_sm, blk_max)
+    tl.store(y_ptr + in_ptrs, y, mask=mask)
+
+
+@torch.library.custom_op("gemlite::scale_activations_triton", mutates_args=())
+def scale_activations_triton(x: Tensor, w_dtype: torch.dtype, max_val: float, fp32_scale: bool = True) -> Tuple[Tensor, Tensor]:
+    
+    M, K   = x.shape
+    scales = torch.empty((M, 1), dtype=torch.float32 if fp32_scale else x.dtype, device=x.device)
+    y      = torch.empty((M, K), dtype=w_dtype, device=x.device)
+
+    BLOCK_M = 1
+    BLOCK_K = triton.next_power_of_2(K)
+    grid    = (triton.cdiv(M, BLOCK_M), triton.cdiv(K, BLOCK_K))
+
+    scale_activations_kernel[grid](
+        x, scales, y,
+        M, K,
+        x.stride(0), x.stride(1),
+        scales.stride(0),
+        max_val=max_val,
+        fp32_scale=fp32_scale,
+        BLOCK_M=BLOCK_M, BLOCK_K=BLOCK_K,
+    )
+
+    return y, scales
+
+@torch.library.register_fake("gemlite::scale_activations_triton")
+def scale_activations_triton_fake(x: Tensor, w_dtype: torch.dtype, max_val: float, fp32_scale: bool = True) -> Tuple[Tensor, Tensor]:
+    M, K = x.shape
+    return torch.empty((M, K), dtype=w_dtype, device=x.device), torch.empty((M, 1), dtype=torch.float32 if fp32_scale else x.dtype, device=x.device)
+
+scale_activations = scale_activations_torch #scale_activations_torch
 
 ############################################################################################################################################################
 #16-bit activations / 8-bit weigths

--- a/gemlite/helper.py
+++ b/gemlite/helper.py
@@ -151,13 +151,12 @@ class A8W8_dynamic:
                         scaled_activations=True,
                         )
 
-
-        gemlite_linear.meta_dtype = DType.FP32
         gemlite_linear.pack(W_q, scales / self.weight_scale, 
                             zeros=None, 
                             bias=bias.to(device=self.device, dtype=dtype) if bias is not None else None, 
                             contiguous=False)
-        
+
+        gemlite_linear.meta_dtype         = DType.FP32
         gemlite_linear.W_group_mode       = 0
         gemlite_linear.channel_scale_mode = 3 #activation[:,None] + weight[None,:]
         return gemlite_linear

--- a/gemlite/helper.py
+++ b/gemlite/helper.py
@@ -4,6 +4,7 @@
 import torch, gc
 from typing import Tuple
 from tqdm import tqdm
+from functools import partial
 from gemlite.core import GemLiteLinearTriton, DType, GEMLITE_ACC_DTYPE, TORCH_TO_DTYPE
 
 def scale_activations(x: torch.Tensor, w_dtype: torch.dtype, max_val: float, fp32_scale: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -163,7 +164,7 @@ class A8W8_dynamic:
 
 
         gemlite_linear.meta_dtype         = DType.FP32
-        gemlite_linear.scale_activationss = lambda x: scale_activations(x, w_dtype=w_dtype, max_val=max_val, fp32_scale=True) 
+        gemlite_linear.scale_activationss = partial(scale_activations, w_dtype=w_dtype, max_val=max_val, fp32_scale=True) 
 
         gemlite_linear.pack(W_q, scales / self.weight_scale, 
                             zeros=None, 
@@ -242,7 +243,7 @@ class A8Wn_dynamic(A16Wn):
         if(fp32_scale):
             gemlite_linear.meta_dtype = DType.FP32
 
-        gemlite_linear.scale_activationss = lambda x: scale_activations(x, w_dtype=w_dtype, max_val=max_val, fp32_scale=fp32_scale)
+        gemlite_linear.scale_activationss = partial(scale_activations, w_dtype=w_dtype, max_val=max_val, fp32_scale=fp32_scale) 
 
         if(group_size == in_features):
             if(self.post_scale):
@@ -362,7 +363,7 @@ class A8W158:
             gemlite_linear.meta_dtype = DType.FP32
 
         #post-scale
-        gemlite_linear.scale_activationss  = lambda x: scale_activations(x, w_dtype=w_dtype, max_val=max_val, fp32_scale=self.fp32_scale)
+        gemlite_linear.scale_activationss = partial(scale_activations, w_dtype=w_dtype, max_val=max_val, fp32_scale=self.fp32_scale) 
         gemlite_linear.W_group_mode       = 1 #shift only
         gemlite_linear.channel_scale_mode = 3 #activations + weight
 

--- a/gemlite/triton_kernels/config.py
+++ b/gemlite/triton_kernels/config.py
@@ -10,7 +10,6 @@ class AUTOTUNE_ENABLE:
 	GEMV_SPLITK    = True
 	GEMM_SPLITK    = True
 	GEMM           = True
-	EXHAUSTIVE     = False
 	USE_CUDA_GRAPH = False
 
 def reload_all_modules():
@@ -18,25 +17,19 @@ def reload_all_modules():
 	from . import gemv_A16fWnO16f_int32packing
 	from . import gemm_A16fWnO16f_int32packing
 	from . import gemm_splitK_A16fWnO16f_int32packing
+	from . import gemm_splitK_persistent_A16fWnO16f_int32packing
 	from . import gemv_revsplitK_A16fWnO16f_int32packing
 
-	MODULES = {'GEMV':[gemv_A16fWnO16f_int32packing], 
-			   'GEMM': [gemm_A16fWnO16f_int32packing], 
-			   'GEMM_SPLITK':[gemm_splitK_A16fWnO16f_int32packing],
-			   'GEMV_REVSPLITK':[gemv_revsplitK_A16fWnO16f_int32packing]
-			   }
-
-	for matmul_dtype in MODULES:
-		for module in MODULES[matmul_dtype]:
-			imp.reload(module)
+	imp.reload(gemv_A16fWnO16f_int32packing)
+	imp.reload(gemm_A16fWnO16f_int32packing)
+	imp.reload(gemm_splitK_A16fWnO16f_int32packing)
+	imp.reload(gemm_splitK_persistent_A16fWnO16f_int32packing)
+	imp.reload(gemv_revsplitK_A16fWnO16f_int32packing)
 
 def set_autotune(matmul_dtypes: dict, **kwargs):
 	for key in matmul_dtypes:
 		setattr(AUTOTUNE_ENABLE, key, matmul_dtypes[key])
 	reload_all_modules()
-
-	if('exhaustive' in kwargs):
-		AUTOTUNE_ENABLE.EXHAUSTIVE: bool = kwargs['exhaustive']
 
 	if('use_cuda_graph' in kwargs):
 		AUTOTUNE_ENABLE.CUDA_GRAPH: bool = kwargs['use_cuda_graph']

--- a/gemlite/triton_kernels/gemm_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_A16fWnO16f_int32packing.py
@@ -288,16 +288,12 @@ def gemm_A16fWnO16f_int32packing_kernel(
     tl.store(c_ptrs, acc, mask=(offs_cm[:, None] < M) & (offs_cn[None, :] < N)) 
 
 
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemm_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemm_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                          W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
                                          input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
                                          channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
                                         ) -> Tensor:
     
-
     M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
 
     M_CLOSEST = utils.get_closest_m(M)
@@ -330,17 +326,7 @@ def gemm_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
 
     return output
 
-@torch.library.register_fake("gemlite::gemm_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemm_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                              W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                              input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                              channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                              ) -> Tensor:
-
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-
-
+    
 class gemm_A16fWnO16f:
     kernel = gemm_A16fWnO16f_int32packing_kernel
     forward = gemm_A16fWnO16f_int32packing_forward

--- a/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_splitK_A16fWnO16f_int32packing.py
@@ -333,10 +333,6 @@ def gemm_splitK_A16fWnO16f_int32packing_kernel(
     else:
         tl.store(c_ptrs, acc, mask=mask) 
 
-
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemm_splitK_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemm_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                                 W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int,
                                                 input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
@@ -378,17 +374,6 @@ def gemm_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
         output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
-
-@torch.library.register_fake("gemlite::gemm_splitK_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemm_splitK_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                              W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                              input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                              channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                              ) -> Tensor:
-    
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-
 
 class gemm_splitK_A16fWnO16f:
     kernel = gemm_splitK_A16fWnO16f_int32packing_kernel

--- a/gemlite/triton_kernels/gemm_splitK_persistent_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemm_splitK_persistent_A16fWnO16f_int32packing.py
@@ -331,9 +331,6 @@ def gemm_splitK_persistent_A16fWnO16f_int32packing_kernel(
             tl.store(c_ptrs, acc, mask=mask)
 
 
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemm_splitK_persistent_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemm_splitK_persistent_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                                 W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int,
                                                 input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
@@ -378,16 +375,6 @@ def gemm_splitK_persistent_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tenso
         output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
-
-@torch.library.register_fake("gemlite::gemm_splitK_persistent_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemm_splitK_persistent_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                              W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                              input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                              channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                              ) -> Tensor:
-    
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
 
 
 class gemm_splitK_persistent_A16fWnO16f:

--- a/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_A16fWnO16f_int32packing.py
@@ -288,9 +288,6 @@ def gemv_A16fWnO16f_int32packing_kernel(
     tl.atomic_add(c_ptrs, acc, sem=atomic_mode) 
 
 
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemv_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                          W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
                                          input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int,  
@@ -331,16 +328,6 @@ def gemv_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor,
         output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
-
-@torch.library.register_fake("gemlite::gemv_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemv_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                              W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                              input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                              channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                              ) -> Tensor:
-
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
 
 
 class gemv_A16fWnO16f:

--- a/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_revsplitK_A16fWnO16f_int32packing.py
@@ -305,9 +305,6 @@ def gemv_revsplitK_A16fWnO16f_int32packing_kernel(
     tl.atomic_add(c_ptrs, acc, sem=atomic_mode)
 
 
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemv_revsplitK_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemv_revsplitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                                    W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
                                                    input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
@@ -356,16 +353,6 @@ def gemv_revsplitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scale
         output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
-
-@torch.library.register_fake("gemlite::gemv_revsplitK_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemv_revsplitK_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                                        W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                                        input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                                        channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                                        ) -> Tensor:
-
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
 
 
 class gemv_revsplitK_A16fWnO16f:

--- a/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
+++ b/gemlite/triton_kernels/gemv_splitK_A16fWnO16f_int32packing.py
@@ -354,9 +354,6 @@ def gemv_splitK_A16fWnO16f_int32packing_kernel(
         tl.atomic_add(c_ptrs, acc, mask=mask, sem=atomic_mode) 
 
 
-_costum_op_id = '_' + str(int(random.random()*10000))
-
-@torch.library.custom_op("gemlite::gemv_splitK_A16fWnO16f_int32packing_forward" + _costum_op_id, mutates_args=())
 def gemv_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
                                                 W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int,
                                                 input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
@@ -400,17 +397,6 @@ def gemv_splitK_A16fWnO16f_int32packing_forward(x: Tensor, W_q: Tensor, scales: 
         output = output.to(DTYPE_TO_TORCH[output_dtype])
 
     return output
-
-@torch.library.register_fake("gemlite::gemv_splitK_A16fWnO16f_int32packing_forward" + _costum_op_id)
-def gemv_splitK_A16fWnO16f_int32packing_forward_fake(x: Tensor, W_q: Tensor, scales: Tensor, zeros: Tensor, scales_x: Tensor,
-                                              W_nbits: int, group_size: int, unpack_mask: int, elements_per_sample: int, 
-                                              input_dtype: int, output_dtype: int, acc_dtype: int, meta_dtype:int, 
-                                              channel_scale_mode: int, W_group_mode: int, data_contiguous: bool,
-                                              ) -> Tensor:
-    
-    M, K, N = x.shape[0], x.shape[1], W_q.shape[1]
-    return torch.empty((M, N), device=W_q.device, dtype=DTYPE_TO_TORCH[output_dtype])
-
 
 class gemv_splitK_A16fWnO16f:
     kernel = gemv_splitK_A16fWnO16f_int32packing_kernel

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name='gemlite',
-    version="0.4.5",
+    version="0.4.6",
     url="https://github.com/mobiusml/gemlite/",
     author="Dr. Hicham Badri",
     author_email="hicham@mobiuslabs.com",

--- a/tests/test_gemlitelineartriton.py
+++ b/tests/test_gemlitelineartriton.py
@@ -2,7 +2,7 @@
 
 import unittest
 import torch
-from gemlite.core import GemLiteLinearTriton, DType, set_autotune, TORCH_TO_DTYPE
+from gemlite.core import GemLiteLinearTriton, DType, set_autotune, TORCH_TO_DTYPE, scale_activations
 
 def is_fp8_supported():
     if not torch.cuda.is_available():
@@ -34,7 +34,7 @@ def gen_data(in_features, out_features, W_nbits, group_size, dtype=compute_dtype
 	return W, W_q, scales, zeros
 
 
-in_features, out_features = 4096, 4096
+in_features, out_features = 4096, 2048
 batch_sizes               = [1, 4]
 W_nbits, group_size       = 4, 128 #128 / in_features
 W, W_q, scales, zeros     = gen_data(in_features, out_features, W_nbits=W_nbits, group_size=group_size)
@@ -49,8 +49,6 @@ def scale_fct(x, max_val, w_dtype):
 class TestGemLiteLinearTriton(unittest.TestCase):
 
 	def test_fp16xfp16(self):
-
-
 		gemlite_linear = GemLiteLinearTriton(W_nbits=16, 
 						group_size=None, 
 						in_features=in_features, 
@@ -157,12 +155,7 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 
 
 		gemlite_linear.pack(W_q, scales=None, zeros=7, bias=None);
-
-		def scaled_activations(x):
-			return scale_fct(x, max_val=127, w_dtype=torch.int8)
-
-		gemlite_linear.scale_activations = scaled_activations
-		gemlite_linear.meta_dtype        = DType.FP32
+		gemlite_linear.meta_dtype = DType.FP32
 
 		#Weights are unpacked() then shifted by 7
 		self.assertTrue(gemlite_linear.W_group_mode == 1) 
@@ -173,15 +166,14 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 
 		for batch_size in batch_sizes:
 			x = torch.randn((batch_size, in_features), dtype=torch.float16, device=device) / 20.
-			
-			_x, _x_scaled = scaled_activations(x)
+			_x, _x_scaled = scale_activations(x, w_dtype=torch.int8)
 			y_ref = torch.matmul(_x.to(torch.float16), (W_q.to(torch.float16) - 7).T) * _x_scaled
 
 			for matmul_type in matmul_types:
 				if(batch_size>1  and 'GEMV' in matmul_type): continue
 				y_gem = gemlite_linear.forward_manual(x, matmul_type=matmul_type)
 				err   = (y_ref - y_gem).abs().mean().item()
-				self.assertTrue(err < tol, str(err) + ', expected < ' + str(tol))
+				self.assertTrue(err < tol, str(err) + ', expected < ' + str(tol) + ' | ' + matmul_type)
 
 	def test_int8Wn_scaled_weights_scaled_activations(self):
 		#INT8 x Wn - activation scaling only
@@ -197,11 +189,6 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 		_scales = torch.randn((out_features, 1), dtype=compute_dtype, device=device) * 1e-4
 		gemlite_linear.pack(W_q, scales=_scales, zeros=7, bias=None);
 
-		#Scaling activations
-		def scaled_activations(x):
-			return scale_fct(x, max_val=127, w_dtype=torch.int8)
-		gemlite_linear.scale_activations = scaled_activations
-
 		#Weights are unpacked() then shifted by 7 if group_size == in_features (1), otherwise (3)
 		self.assertTrue(gemlite_linear.W_group_mode == 1) 
 		#Activations only are scaled if group_size != in_features (2) otherwise bot are scales merged (3)
@@ -212,13 +199,13 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 		for batch_size in batch_sizes:
 			shape = W_q.shape
 			x = torch.randn((batch_size, in_features), dtype=compute_dtype, device=device) / 10.
-			_x, _x_scaled = scaled_activations(x)
+			_x, _x_scaled = scale_activations(x, w_dtype=torch.int8)
 			y_ref = torch.matmul(_x.to(compute_dtype), ((W_q.to(compute_dtype) - 7) * _scales).T) * _x_scaled
 			for matmul_type in matmul_types:
 				if(batch_size>1  and 'GEMV' in matmul_type): continue
 				y_gem = gemlite_linear.forward_manual(x, matmul_type=matmul_type)
 				err   = (y_ref - y_gem).abs().mean().item()
-				self.assertTrue(err < tol, str(err) + ', expected < ' + str(tol))
+				self.assertTrue(err < tol, str(err) + ', expected < ' + str(tol) + ' | ' + matmul_type)
 
 
 	@unittest.skipIf(not is_fp8_supported(), "Skipping test: GPU does not support FP8")
@@ -268,12 +255,6 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 		_scales = torch.randn((1, out_features), dtype=compute_dtype, device=device) * 1e-4
 		gemlite_linear.pack(W.to(fp8_dtype), scales=_scales, zeros=None, bias=None);
 
-		#Scaling activations
-		scales_x = torch.ones((1, 1), dtype=compute_dtype, device='cuda:0') * 0.1
-		def scaled_activations(x):
-			return x, scales_x
-		gemlite_linear.scale_activations = scaled_activations
-
 		#No weight unpacking / dequant
 		self.assertTrue(gemlite_linear.W_group_mode == 0)
 		#Both activations and weights are scales
@@ -283,8 +264,10 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 
 		for batch_size in batch_sizes:
 			shape = W.shape
-			x = (torch.randn((batch_size, in_features), dtype=compute_dtype, device=device) / 10.).to(fp8_dtype)
-			y_ref = torch.matmul(x.to(compute_dtype), W.T) * (_scales * scales_x)
+			x = torch.randn((batch_size, in_features), dtype=compute_dtype, device=device) / 10.
+			_x, scales_x = scale_activations(x, w_dtype=fp8_dtype)
+
+			y_ref = torch.matmul(_x.to(compute_dtype), W.T) * (_scales * scales_x)
 			for matmul_type in matmul_types:
 				if(batch_size>1  and 'GEMV' in matmul_type): continue
 				y_gem = gemlite_linear.forward_manual(x, matmul_type=matmul_type)
@@ -315,16 +298,12 @@ class TestGemLiteLinearTriton(unittest.TestCase):
 			self.assertTrue(gemlite_linear.W_group_mode == 3)
 			self.assertTrue(gemlite_linear.channel_scale_mode == 2)
 
-		#Scaling activations
-		def scaled_activations(x):
-			return scale_fct(x, max_val=torch.finfo(fp8_dtype).max, w_dtype=fp8_dtype)
-		gemlite_linear.scale_activations = scaled_activations
 
 		tol = 5e-3 #needs higher tolerance with fp8
 
 		for batch_size in batch_sizes:
 			x = (torch.randn((batch_size, in_features), dtype=compute_dtype, device=device) / 10.).to(fp8_dtype).to(compute_dtype)
-			_x, _scaled_x = scaled_activations(x)
+			_x, _scaled_x = scale_activations(x, w_dtype=fp8_dtype)
 			y_ref = torch.matmul(_x.to(compute_dtype), W.T) * _scaled_x
 			for matmul_type in matmul_types:
 				if(batch_size>1  and 'GEMV' in matmul_type): continue


### PR DESCRIPTION
This PR makes gemlite compatible with vllm V1 (torch.compile). It required some major changes, mainly moving everything related to the forward pass inside a custom_op (including activation quantization). 
End-2-end speed-up up to ~1.25x with vllm V1 vs V0 !